### PR TITLE
feat: decouple GraphQL API from persistence

### DIFF
--- a/src/invenira_backend_schema.graphql
+++ b/src/invenira_backend_schema.graphql
@@ -34,9 +34,6 @@ type ActivityGQLSchema {
     "The Activity Configuration Parameters."
     parameters: Record!,
 
-    "The Activity Provider id that provides this Activity"
-    activityProviderId: MongoIdScalar!,
-
     "The timestamp when the Activity was created."
     createdAt: Date!,
 
@@ -82,6 +79,9 @@ type ActivityProviderGQLSchema {
 
     "The Activity Provider base URl."
     url: String!,
+
+    "The list of activities provided by this Activity Provider"
+    activities: [ActivityGQLSchema!]!,
 
     "The timestamp when the Activity Provider was created."
     createdAt: Date!,
@@ -182,8 +182,8 @@ type IAPGQLSchema {
     "The IAP Description."
     description: String!,
 
-    "The list of Activity Ids included in the IAP"
-    activityIds: [MongoIdScalar!]!,
+    "The list of Activity Providers used by the IAP"
+    activityProviders: [ActivityProviderGQLSchema!]!,
 
     """
     Weather this IAP is deployed or not. Being deployed means that the system has engaged with all Activity Providers to
@@ -194,8 +194,8 @@ type IAPGQLSchema {
     "The deploy URL for each activity"
     deployUrls: Record!,
 
-    "The list of Goal Ids included in the IAP"
-    goalIds: [MongoIdScalar!]!,
+    "The list of Goal included in the IAP"
+    goals: [MongoIdScalar!]!,
 
     "The timestamp when the IAP was created."
     createdAt: Date!,

--- a/src/invenira_backend_schema.graphql
+++ b/src/invenira_backend_schema.graphql
@@ -195,7 +195,7 @@ type IAPGQLSchema {
     deployUrls: Record!,
 
     "The list of Goal included in the IAP"
-    goals: [MongoIdScalar!]!,
+    goals: [GoalGQLSchema!]!,
 
     "The timestamp when the IAP was created."
     createdAt: Date!,

--- a/src/lib/activity-provider.ts
+++ b/src/lib/activity-provider.ts
@@ -1,10 +1,7 @@
 import { z } from 'zod';
 import { ActivitySchema } from './activity';
-import { Metadata, Validate, Schema, MongoIdSchema } from './base';
-import {
-  ActivityProviderGQLSchema,
-  CreateActivityProviderInput,
-} from '../types/graphql.types';
+import { Metadata, MongoIdSchema, Schema, Validate } from './base';
+import { ActivityProviderGQLSchema, CreateActivityProviderInput } from '../types/graphql.types';
 
 export const ActivityProviderSchema = z
   .object({
@@ -12,6 +9,7 @@ export const ActivityProviderSchema = z
     name: z.string().nonempty(),
     description: z.string().nonempty(),
     url: z.string().url(),
+    activities: z.array(ActivitySchema),
     createdAt: z.date(),
     createdBy: z.string().nonempty(),
     updatedAt: z.date(),

--- a/src/lib/activity-provider.ts
+++ b/src/lib/activity-provider.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 import { ActivitySchema } from './activity';
 import { Metadata, MongoIdSchema, Schema, Validate } from './base';
-import { ActivityProviderGQLSchema, CreateActivityProviderInput } from '../types/graphql.types';
+import {
+  ActivityProviderGQLSchema,
+  CreateActivityProviderInput,
+} from '../types/graphql.types';
 
 export const ActivityProviderSchema = z
   .object({

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -12,7 +12,6 @@ export const ActivitySchema = z
     name: z.string().nonempty(),
     description: z.string().nonempty(),
     parameters: z.record(z.string(), z.any()),
-    activityProviderId: MongoIdSchema,
     createdAt: z.date(),
     createdBy: z.string().nonempty(),
     updatedAt: z.date(),

--- a/src/lib/iap.ts
+++ b/src/lib/iap.ts
@@ -1,16 +1,18 @@
 import { z } from 'zod';
 import { Metadata, MongoIdSchema, Schema, Validate } from './base';
 import { CreateIAPInput, IAPGQLSchema } from '../types/graphql.types';
+import { ActivityProviderSchema } from './activity-provider';
+import { GoalSchema } from './goal';
 
 export const IAPSchema = z
   .object({
     _id: MongoIdSchema,
     name: z.string().nonempty(),
     description: z.string().nonempty(),
-    activityIds: z.array(MongoIdSchema),
+    activityProviders: z.array(ActivityProviderSchema),
     isDeployed: z.boolean(),
     deployUrls: z.record(z.string(), z.string().url()),
-    goalIds: z.array(MongoIdSchema),
+    goals: z.array(GoalSchema),
     createdAt: z.date(),
     createdBy: z.string().nonempty(),
     updatedAt: z.date(),

--- a/src/types/graphql.types.ts
+++ b/src/types/graphql.types.ts
@@ -48,7 +48,6 @@ export class ActivityGQLSchema {
     name: string;
     description: string;
     parameters: Record;
-    activityProviderId: MongoIdScalar;
     createdAt: Date;
     createdBy: string;
     updatedAt: Date;
@@ -60,6 +59,7 @@ export class ActivityProviderGQLSchema {
     name: string;
     description: string;
     url: string;
+    activities: ActivityGQLSchema[];
     createdAt: Date;
     createdBy: string;
     updatedAt: Date;
@@ -86,10 +86,10 @@ export class IAPGQLSchema {
     _id: MongoIdScalar;
     name: string;
     description: string;
-    activityIds: MongoIdScalar[];
+    activityProviders: ActivityProviderGQLSchema[];
     isDeployed: boolean;
     deployUrls: Record;
-    goalIds: MongoIdScalar[];
+    goals: GoalGQLSchema[];
     createdAt: Date;
     createdBy: string;
     updatedAt: Date;


### PR DESCRIPTION
## Changes

- Decouple GraphQL API from persistence layer, meaning that entities should not return IDs of related entities but the actual entities. The persistence layer should sort the dependencies to allow GraphQL API Clients to access records in a single query.